### PR TITLE
Fix bisq.markets hostname

### DIFF
--- a/src/index-bisq.ts
+++ b/src/index-bisq.ts
@@ -7,7 +7,7 @@ import { useStatistics as useStatisticsBisq } from './app/bisq/statistics';
 import { useTransactions as useTransactionsBisq } from './app/bisq/transactions';
 import { useMarkets as useMarkets } from './app/bisq/markets';
 
-const hostnameEndpointDefault = 'bisq.market';
+const hostnameEndpointDefault = 'bisq.markets';
 const networkEndpointDefault = 'bisq';
 
 const mempool = ({ hostname, network }: MempoolConfig = {


### PR DESCRIPTION
I'm testing code samples while re-writing the docs section and examples that use `bisq.js` are broken on the live website. 

It seems that's because there's a reference to `bisq.market` instead of `bisq.markets` in `bisq.js`.