### PR TITLE
fix: return type of txMerkleProof

### DIFF
--- a/src/app/bitcoin/transactions.ts
+++ b/src/app/bitcoin/transactions.ts
@@ -36,7 +36,7 @@ export const useTransactions = (api: AxiosInstance): TxInstance => {
   };
 
   const getTxMerkleProof = async (params: { txid: string }) => {
-    const { data } = await api.get<Array<TxMerkleProof>>(
+    const { data } = await api.get<TxMerkleProof>(
       `/tx/${params.txid}/merkle-proof`
     );
     return data;

--- a/src/app/liquid/transactions.ts
+++ b/src/app/liquid/transactions.ts
@@ -36,7 +36,7 @@ export const useTransactions = (api: AxiosInstance): TxInstance => {
   };
 
   const getTxMerkleProof = async (params: { txid: string }) => {
-    const { data } = await api.get<Array<TxMerkleProof>>(
+    const { data } = await api.get<TxMerkleProof>(
       `/tx/${params.txid}/merkle-proof`
     );
     return data;

--- a/src/interfaces/bitcoin/transactions.ts
+++ b/src/interfaces/bitcoin/transactions.ts
@@ -52,7 +52,7 @@ export interface TxInstance {
   getTxHex: (params: { txid: string }) => Promise<string>;
   getTxRaw: (params: { txid: string }) => Promise<string>;
   getTxMerkleBlockProof: (params: { txid: string }) => Promise<string>;
-  getTxMerkleProof: (params: { txid: string }) => Promise<Array<TxMerkleProof>>;
+  getTxMerkleProof: (params: { txid: string }) => Promise<TxMerkleProof>;
   getTxOutspend: (params: {
     txid: string;
     vout: number;


### PR DESCRIPTION
The interface for returning `getTxMerkleProof()` is an array. That did not match the actual return from the mempool API. This PR fixes the return type.

examples: 
https://mempool.space/docs/api/rest#get-transaction-merkle-proof
https://liquid.network/docs/api/rest#get-transaction-merkle-proof