### PR TITLE
fix bug on transaction push body

### DIFF
--- a/src/app/bitcoin/transactions.ts
+++ b/src/app/bitcoin/transactions.ts
@@ -57,7 +57,7 @@ export const useTransactions = (api: AxiosInstance): TxInstance => {
   };
 
   const postTx = async (params: { txhex: string }) => {
-    const { data } = await api.post<string>(`/tx`, { txhex: params.txhex });
+    const { data } = await api.post<string>(`/tx`, params.txhex );
     return data;
   };
 

--- a/src/app/liquid/transactions.ts
+++ b/src/app/liquid/transactions.ts
@@ -57,7 +57,7 @@ export const useTransactions = (api: AxiosInstance): TxInstance => {
   };
 
   const postTx = async (params: { txhex: string }) => {
-    const { data } = await api.post<string>(`/tx`, { txid: params.txhex });
+    const { data } = await api.post<string>(`/tx`, params.txhex );
     return data;
   };
 


### PR DESCRIPTION
The [POST Transaction](https://mempool.space/it/docs/api/rest#post-transaction) endpoint requires a plain text body.
The current library post a json object.
This pull request fixes the bug.