### PR TITLE
fix wsClient

### DIFF
--- a/src/services/ws/client.ts
+++ b/src/services/ws/client.ts
@@ -1,4 +1,4 @@
-const serverWS = (
+const wsClient = (
   options: string[],
   endpoint: string,
 ): WebSocket => {
@@ -21,5 +21,5 @@ const sleep = (ms: number) => {
   });
 };
 
-export default serverWS;
+export default wsClient;
 


### PR DESCRIPTION
confusing typo as it's called from here https://github.com/mempool/mempool.js/blob/3b99ee2643b9d57fbc520be0e87461ae557b040c/src/app/bitcoin/websocket.ts#L10